### PR TITLE
feat(ui): remove authentication-related navigation items

### DIFF
--- a/unkot/templates/base.html
+++ b/unkot/templates/base.html
@@ -62,28 +62,7 @@
                             <li class="nav-item">
                                 <a class="nav-link" href="{% url 'about' %}">{% translate "About" %}</a>
                             </li>
-                            {% if request.user.is_authenticated %}
-                                <li class="nav-item">
-                                    {# URL provided by django-allauth/account/urls.py #}
-                                    <a class="nav-link"
-                                       href="{% url 'users:detail' request.user.username %}">{% translate "My Profile" %}</a>
-                                </li>
-                                <li class="nav-item">
-                                    {# URL provided by django-allauth/account/urls.py #}
-                                    <a class="nav-link" href="{% url 'account_logout' %}">{% translate "Sign Out" %}</a>
-                                </li>
-                            {% else %}
-                                {% if ACCOUNT_ALLOW_REGISTRATION %}
-                                    <li class="nav-item">
-                                        {# URL provided by django-allauth/account/urls.py #}
-                                        <a id="sign-up-link" class="nav-link" href="{% url 'account_signup' %}">{% translate "Sign Up" %}</a>
-                                    </li>
-                                {% endif %}
-                                <li class="nav-item">
-                                    {# URL provided by django-allauth/account/urls.py #}
-                                    <a id="log-in-link" class="nav-link" href="{% url 'account_login' %}">{% translate "Sign In" %}</a>
-                                </li>
-                            {% endif %}
+                            {# User authentication disabled #}
                             {% if request.user.is_superuser %}
                                 <li class="nav-item">
                                     <a class="nav-link" href="{% url 'admin:index' %}">Django Admin</a>


### PR DESCRIPTION
- Remove user login/logout/signup links
- Preserve Django admin link for superusers
- Commented out entire authentication block

This change simplifies the navigation and removes user-facing authentication options.

🤖 Generated with [Claude Code](https://claude.ai/code)